### PR TITLE
Fix social links

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -234,17 +234,17 @@
               <!-- Social Icons -->
               <div class="flex space-x-4 mt-4">
                 <a
-                  href="www.facebook.com"
+                  href="https://www.facebook.com"
                   class="text-gray-400 hover:text-rose-600 transition-colors">
                   <i class="fab fa-facebook"></i>
                 </a>
                 <a
-                  href="www.x.com"
+                  href="https://www.x.com"
                   class="text-gray-400 hover:text-rose-600 transition-colors">
                   <i class="fab fa-twitter"></i>
                 </a>
                 <a
-                  href="www.instagram.com"
+                  href="https://www.instagram.com"
                   class="text-gray-400 hover:text-rose-600 transition-colors">
                   <i class="fab fa-instagram"></i>
                 </a>

--- a/templates/errors/404.html
+++ b/templates/errors/404.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% load static %}
-{% block title %}404 Error
+{% block title %}
+404 Error
 {% endblock %}
 {% block content %}
 


### PR DESCRIPTION
Social links in footer were missing `https://` prefix and so were directing to `<our-site>/www.instagram.com`.